### PR TITLE
Document visits setup and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,94 @@
 # CRM Project
-This repository contains a simple CRM skeleton with a Node.js/Express backend and a placeholder React frontend.
 
-## Visits Feature Documentation
-Detailed API references, dashboard walkthroughs, and seeding instructions for the Visits experience now live in [`docs/README.md`](docs/README.md). Review that guide when working on `/api/visits/*` endpoints or testing the Visits Dashboard UI.
+This monorepo houses a lightweight CRM prototype composed of a Node.js/Express backend and a placeholder React frontend. Use the sections below to install dependencies, bring both tiers online, and exercise the new Visits Dashboard flows.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18 or newer and the accompanying `npm` CLI.
+- SQLite is bundled by default—no additional database service is required.
+
+## Backend: Install, Test, and Run
+
+1. Install dependencies:
+
+   ```bash
+   cd backend
+   npm install
+   ```
+
+2. (Optional) Run the automated tests:
+
+   ```bash
+   npm test
+   ```
+
+3. Start the API server. The service boots on port `5000` by default and automatically provisions the SQLite data directory (`../data/database.sqlite`).
+
+   ```bash
+   node index.js
+   ```
+
+   Set `PORT` to override the listen port or `SQLITE_STORAGE`/`DATABASE_URL` to target a different database location if needed.
+
+Key routes include:
+
+- `POST /api/auth/login` – authenticate with one of the sample accounts below.
+- `GET /api/health` – quick readiness probe for monitoring and automated tests.
+
+## Frontend: Install and Run
+
+1. Install dependencies (the scaffold currently has no runtime packages, but running `npm install` keeps the workflow consistent once React tooling is added):
+
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+2. Serve the app. The simplest option today is to open `frontend/index.html` in a browser or run any static file server (for example `npx serve .`) and navigate to the hosted page. When a full React toolchain lands, replace this step with the appropriate `npm start` or Vite/CRA dev server command.
+
+3. Frontend tests: after the project is wired up with a test runner (Jest, Vitest, etc.), execute the suite from the `frontend/` directory. The recommended convention is:
+
+   ```bash
+   npm test
+   ```
+
+   Update the `"test"` script in `frontend/package.json` once the tooling is configured so `npm test` runs the actual checks.
+
+## Sample Accounts and Roles
+
+Use these credentials with `POST /api/auth/login` while exercising role-based features:
+
+| Role   | Email                 | Password       | Notes |
+| ------ | --------------------- | -------------- | ----- |
+| Admin  | `admin@example.com`   | `password`     | Seeded in-memory by the Express app for local authentication. |
+| Manager | `manager@example.com` | `Password123!` | Create via your seeding workflow—see [`docs/README.md`](docs/README.md) for context on seeding users and roles. |
+| Rep    | `rep@example.com`     | `Password123!` | Create via your seeding workflow—see [`docs/README.md`](docs/README.md). |
+
+## Visits Dashboard Overview
+
+- **Entry Point:** Once authenticated, navigate to the Visits Dashboard from the primary navigation menu in the frontend. The page aggregates field activity for the authenticated persona.
+- **Role Access:**
+  - **Sales Representatives** focus on their own route planning and completed visits.
+  - **Sales Managers** monitor team activity, summary metrics, and CSV exports for coaching and reporting.
+  - **Admins** can impersonate or configure either group as new tooling is introduced.
+
+Refer to [`docs/README.md`](docs/README.md) for a full walkthrough of the filters panel, summary cards, visits table, and CSV export controls that compose the dashboard experience.【F:docs/README.md†L5-L60】
+
+## Visits API Endpoints
+
+The Visits Dashboard is powered by the `/api/visits/*` endpoints. The detailed reference—including request parameters, sample responses, and CSV export headers—lives in [`docs/README.md`](docs/README.md).【F:docs/README.md†L5-L46】 Highlights include:
+
+- `GET /api/visits/summary`
+  - Returns aggregate visit metrics for the active filters so the dashboard can render summary cards and charts.
+  - Supports `startDate`, `endDate`, `repId`, `hcpId`, and `status` query parameters for granular filtering.
+- `GET /api/visits/export`
+  - Streams a CSV with the same filters applied to the dashboard table.
+  - Accepts the same query parameters as the summary endpoint plus `timezone` and `includeNotes` to customize exports.
+
+Use these endpoints in tandem with the seed scripts described in `docs/README.md` to populate visits data and validate the dashboard UX end-to-end.【F:docs/README.md†L34-L67】
+
+## Additional Resources
+
+- [`docs/README.md`](docs/README.md) – authoritative reference for visits endpoints, dashboard behavior, and seeding helpers.
+- [`backend/README.md`](backend/README.md) – quick backend command summary.
+- [`frontend/README.md`](frontend/README.md) – frontend usage notes.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,21 @@
 # Frontend
 
-This directory includes a very small React setup. Open `index.html` in a browser to view the page.
+This directory currently exposes a minimal React entry point rendered via `src/index.js`. Until the full toolchain is wired up, you can work with the scaffold using the steps below.
+
+## Install Dependencies
+
+While no runtime packages are required today, run `npm install` so lockfiles stay in sync once additional tooling (React Router, testing libraries, etc.) is introduced:
+
+```bash
+cd frontend
+npm install
+```
+
+## Start the UI
+
+- **Quick preview:** open `index.html` in a browser to render the placeholder UI.
+- **Local static server:** alternatively, run `npx serve .` (or your preferred static host) from the `frontend/` directory and browse to the reported URL. Replace this step with your framework-specific dev server command when the project adopts one.
+
+## Run Frontend Tests
+
+Once a test runner is configured, execute the suite with `npm test` from the `frontend/` directory. Update the `"test"` script in `package.json` to point to the actual command (for example, `react-scripts test` or `vitest run`).


### PR DESCRIPTION
## Summary
- expand the root README with setup instructions for the backend and frontend, sample authentication accounts, and guidance for the Visits Dashboard and API endpoints
- flesh out the frontend README with dependency, serving, and future test-running instructions so contributors know how to work with the scaffold

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132881881483278a4a6152cccb5a7c)