### PR TITLE
Add Sequelize seed scripts for roles, users, and visits

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,13 +11,22 @@ npm install
 npm test
 ```
 
-To populate realistic fixtures for the Visits dashboard, seed the database. The
-seed resets the SQLite tables and loads sample territories, sales reps, HCPs,
-and visits:
+### Database seeding
 
-```
-npm run seed
-```
+Seed scripts live under `backend/scripts/` and can target any SQLite database by
+setting the `SQLITE_STORAGE` environment variable (defaults to
+`../data/database.sqlite`). Run them in the following order when preparing a new
+environment:
+
+1. `npm run seed:roles` – Creates the default `admin`, `manager`, and `rep` roles.
+2. `npm run seed:users` – Inserts demo users with bcrypt-hashed passwords and
+   associates them with roles.
+3. `npm run seed:visits` – Upserts territories, sales reps, HCPs, and sample
+   visits that match the Visits dashboard.
+
+For convenience, `npm run seed:all` executes the full sequence, and the legacy
+`npm run seed` alias still populates the visit data only. Each script is
+idempotent and can be re-run safely (useful for CI or resetting a dev database).
 
 Start the development server on port `5000` (override via `PORT`):
 
@@ -27,7 +36,8 @@ node index.js
 
 ## Key Endpoints
 
-- `POST /api/auth/login` – Validates credentials against the in-memory admin user.
+- `POST /api/auth/login` – Validates credentials against the persisted `users`
+  table seeded via the scripts above and returns the associated role.
 - `GET /api/health` – Lightweight readiness probe.
 - `GET /api/hcps` – Lists HCP records ordered alphabetically.
 - `POST /api/import/hcps` – Bulk upsert HCP data.

--- a/backend/__tests__/auth.test.js
+++ b/backend/__tests__/auth.test.js
@@ -1,5 +1,18 @@
 const request = require('supertest');
-const { app } = require('..');
+const { app, ready } = require('..');
+const { resetDatabase } = require('../db');
+const { seedRoles } = require('../scripts/seedRoles');
+const { seedUsers } = require('../scripts/seedUsers');
+
+beforeAll(async () => {
+  await ready;
+});
+
+beforeEach(async () => {
+  await resetDatabase();
+  await seedRoles();
+  await seedUsers();
+});
 
 describe('POST /api/auth/login', () => {
   it('authenticates valid credentials', async () => {
@@ -9,9 +22,10 @@ describe('POST /api/auth/login', () => {
       .expect(200);
 
     expect(response.body).toEqual({
-      id: 1,
+      id: expect.any(Number),
       email: 'admin@example.com',
       name: 'Admin User',
+      role: { id: expect.any(Number), name: 'admin' },
     });
   });
 

--- a/backend/__tests__/seedScripts.test.js
+++ b/backend/__tests__/seedScripts.test.js
@@ -1,0 +1,66 @@
+const bcrypt = require('bcryptjs');
+
+const { sequelize, resetDatabase, initDb } = require('../db');
+const { Role, User, Territory, SalesRep, Hcp, Visit } = require('../models');
+const { seedRoles } = require('../scripts/seedRoles');
+const { seedUsers } = require('../scripts/seedUsers');
+const { seedVisits } = require('../scripts/seedVisits');
+const sampleData = require('../db/sampleData');
+
+const runAllSeeds = async () => {
+  await seedRoles();
+  await seedUsers();
+  await seedVisits();
+};
+
+describe('seed scripts', () => {
+  beforeAll(async () => {
+    await initDb();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  test('produce expected counts and are idempotent', async () => {
+    await runAllSeeds();
+
+    const countsAfterFirstRun = {
+      roles: await Role.count(),
+      users: await User.count(),
+      territories: await Territory.count(),
+      salesReps: await SalesRep.count(),
+      hcps: await Hcp.count(),
+      visits: await Visit.count(),
+    };
+
+    expect(countsAfterFirstRun.roles).toBe(3);
+    expect(countsAfterFirstRun.users).toBe(5);
+    expect(countsAfterFirstRun.territories).toBe(sampleData.territories.length);
+    expect(countsAfterFirstRun.salesReps).toBe(sampleData.salesReps.length);
+    expect(countsAfterFirstRun.hcps).toBe(sampleData.hcps.length);
+    expect(countsAfterFirstRun.visits).toBe(sampleData.visits.length);
+
+    const adminUser = await User.findOne({ where: { email: 'admin@example.com' }, include: [{ model: Role, as: 'role' }] });
+    expect(adminUser).toBeTruthy();
+    expect(adminUser.role.name).toBe('admin');
+    expect(await bcrypt.compare('password', adminUser.passwordHash)).toBe(true);
+
+    await runAllSeeds();
+
+    const countsAfterSecondRun = {
+      roles: await Role.count(),
+      users: await User.count(),
+      territories: await Territory.count(),
+      salesReps: await SalesRep.count(),
+      hcps: await Hcp.count(),
+      visits: await Visit.count(),
+    };
+
+    expect(countsAfterSecondRun).toEqual(countsAfterFirstRun);
+  });
+});

--- a/backend/db/seed.js
+++ b/backend/db/seed.js
@@ -1,81 +1,15 @@
-const { initDb, sequelize } = require('./index');
-const { Hcp, Territory, SalesRep, Visit } = require('../models');
-const sampleData = require('./sampleData');
+const { seedVisits } = require('../scripts/seedVisits');
 
-const buildLookupKey = (name, areaTag) => `${name}|${areaTag}`;
-
-const seed = async () => {
-  await initDb();
-
-  const transaction = await sequelize.transaction();
-
-  try {
-    await Visit.destroy({ where: {}, truncate: true, cascade: true, restartIdentity: true, transaction });
-    await SalesRep.destroy({ where: {}, truncate: true, cascade: true, restartIdentity: true, transaction });
-    await Hcp.destroy({ where: {}, truncate: true, cascade: true, restartIdentity: true, transaction });
-    await Territory.destroy({ where: {}, truncate: true, cascade: true, restartIdentity: true, transaction });
-
-    const territories = await Territory.bulkCreate(sampleData.territories, { returning: true, transaction });
-    const territoryByCode = new Map(territories.map(territory => [territory.code, territory]));
-
-    const hcps = await Hcp.bulkCreate(sampleData.hcps, { returning: true, transaction });
-    const hcpByKey = new Map(hcps.map(hcp => [buildLookupKey(hcp.name, hcp.areaTag), hcp]));
-
-    const salesReps = [];
-    for (const rep of sampleData.salesReps) {
-      const territory = territoryByCode.get(rep.territoryCode) || null;
-      const created = await SalesRep.create(
-        {
-          name: rep.name,
-          email: rep.email || null,
-          territoryId: territory ? territory.id : null,
-        },
-        { transaction }
-      );
-      salesReps.push(created);
-    }
-    const repByName = new Map(salesReps.map(rep => [rep.name, rep]));
-
-    const visitPayloads = sampleData.visits.map(visit => {
-      const territory = territoryByCode.get(visit.territoryCode);
-      const rep = repByName.get(visit.repName);
-      const hcp = hcpByKey.get(buildLookupKey(visit.hcpName, visit.hcpAreaTag));
-
-      if (!territory || !rep || !hcp) {
-        throw new Error(`Invalid visit reference for ${visit.repName} / ${visit.hcpName}.`);
-      }
-
-      return {
-        visitDate: visit.visitDate,
-        status: visit.status,
-        durationMinutes: visit.durationMinutes,
-        notes: visit.notes || null,
-        repId: rep.id,
-        hcpId: hcp.id,
-        territoryId: territory.id,
-      };
-    });
-
-    await Visit.bulkCreate(visitPayloads, { transaction });
-
-    await transaction.commit();
-    return { inserted: visitPayloads.length };
-  } catch (error) {
-    await transaction.rollback();
-    throw error;
-  }
-};
+module.exports = seedVisits;
 
 if (require.main === module) {
-  seed()
+  seedVisits()
     .then(result => {
-      console.log(`Seed completed. Inserted ${result.inserted} visits.`);
+      console.log(`Seeded visits. ${result.inserted} new row(s) added.`);
       process.exit(0);
     })
     .catch(error => {
-      console.error('Failed to seed data:', error);
+      console.error('Failed to seed visits:', error);
       process.exit(1);
     });
 }
-
-module.exports = seed;

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const bcrypt = require('bcryptjs');
 
 const { initDb } = require('./db');
+const { User, Role } = require('./models');
 const hcpsRouter = require('./routes/hcps');
 const importRouter = require('./routes/import');
 const visitsRouter = require('./routes/visits');
@@ -11,18 +12,7 @@ const PORT = process.env.PORT || 5000;
 
 app.use(express.json());
 
-// In-memory user seed. Passwords are stored as hashes to avoid leaking
-// credentials when the data store is inspected or logged.
-const users = [
-  {
-    id: 1,
-    email: 'admin@example.com',
-    passwordHash: bcrypt.hashSync('password', 10),
-    name: 'Admin User'
-  }
-];
-
-const loginHandler = (req, res) => {
+const loginHandler = async (req, res) => {
   const { email, password } = req.body || {};
 
   if (typeof email !== 'string' || typeof password !== 'string' || !email.trim() || !password) {
@@ -30,20 +20,36 @@ const loginHandler = (req, res) => {
   }
 
   const normalizedEmail = email.trim().toLowerCase();
-  const user = users.find(u => u.email.toLowerCase() === normalizedEmail);
+  try {
+    await ready;
+    const user = await User.findOne({
+      where: { email: normalizedEmail },
+      include: [{ model: Role, as: 'role' }],
+    });
 
-  if (!user || !bcrypt.compareSync(password, user.passwordHash)) {
-    return res.status(401).json({ message: 'Invalid email or password.' });
+    if (!user || !bcrypt.compareSync(password, user.passwordHash)) {
+      return res.status(401).json({ message: 'Invalid email or password.' });
+    }
+
+    return res.json({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role ? { id: user.role.id, name: user.role.name } : null,
+    });
+  } catch (error) {
+    console.error('Failed to authenticate user:', error);
+    return res.status(500).json({ message: 'Unable to authenticate user right now.' });
   }
-
-  return res.json({ id: user.id, email: user.email, name: user.name });
 };
 
 const healthHandler = (_req, res) => {
   res.json({ status: 'ok' });
 };
 
-app.post('/api/auth/login', loginHandler);
+app.post('/api/auth/login', (req, res, next) => {
+  Promise.resolve(loginHandler(req, res)).catch(next);
+});
 app.get('/api/health', healthHandler);
 app.use('/api/hcps', hcpsRouter);
 app.use('/api/import', importRouter);

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -2,6 +2,8 @@ const Hcp = require('./hcp');
 const Territory = require('./territory');
 const SalesRep = require('./salesRep');
 const Visit = require('./visit');
+const Role = require('./role');
+const User = require('./user');
 
 Hcp.hasMany(Visit, { foreignKey: 'hcpId', as: 'visits' });
 Visit.belongsTo(Hcp, { foreignKey: 'hcpId', as: 'hcp' });
@@ -15,9 +17,14 @@ Visit.belongsTo(SalesRep, { foreignKey: 'repId', as: 'rep' });
 Territory.hasMany(SalesRep, { foreignKey: 'territoryId', as: 'reps' });
 SalesRep.belongsTo(Territory, { foreignKey: 'territoryId', as: 'territory' });
 
+Role.hasMany(User, { foreignKey: 'roleId', as: 'users' });
+User.belongsTo(Role, { foreignKey: 'roleId', as: 'role' });
+
 module.exports = {
   Hcp,
   Territory,
   SalesRep,
   Visit,
+  Role,
+  User,
 };

--- a/backend/models/role.js
+++ b/backend/models/role.js
@@ -1,0 +1,30 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../db');
+
+const Role = sequelize.define('Role', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+    validate: {
+      notEmpty: true,
+    },
+  },
+  description: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  },
+}, {
+  tableName: 'roles',
+  underscored: true,
+  indexes: [
+    { unique: true, fields: ['name'] },
+  ],
+});
+
+module.exports = Role;

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,0 +1,45 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../db');
+
+const User = sequelize.define('User', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    validate: {
+      notEmpty: true,
+    },
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+    validate: {
+      isEmail: true,
+      notEmpty: true,
+    },
+  },
+  passwordHash: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    field: 'password_hash',
+  },
+  roleId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    field: 'role_id',
+  },
+}, {
+  tableName: 'users',
+  underscored: true,
+  indexes: [
+    { unique: true, fields: ['email'] },
+    { fields: ['role_id'] },
+  ],
+});
+
+module.exports = User;

--- a/backend/models/visit.js
+++ b/backend/models/visit.js
@@ -61,6 +61,7 @@ const Visit = sequelize.define('Visit', {
     { fields: ['rep_id'] },
     { fields: ['hcp_id'] },
     { fields: ['territory_id'] },
+    { unique: true, fields: ['visit_date', 'rep_id', 'hcp_id'] },
   ],
 });
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,12 @@
   "description": "This directory will contain the Node.js/Express backend.",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
-    "seed": "node db/seed.js"
+    "test": "jest --runInBand",
+    "seed": "node db/seed.js",
+    "seed:roles": "node scripts/seedRoles.js",
+    "seed:users": "node scripts/seedUsers.js",
+    "seed:visits": "node scripts/seedVisits.js",
+    "seed:all": "npm run seed:roles && npm run seed:users && npm run seed:visits"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/seedRoles.js
+++ b/backend/scripts/seedRoles.js
@@ -1,0 +1,39 @@
+const { initDb, sequelize } = require('../db');
+const { Role } = require('../models');
+
+const roles = [
+  { name: 'admin', description: 'System administrator with full access.' },
+  { name: 'manager', description: 'Regional manager with visibility across teams.' },
+  { name: 'rep', description: 'Sales representative with access to their own visits.' },
+];
+
+const seedRoles = async () => {
+  await initDb();
+  const transaction = await sequelize.transaction();
+
+  try {
+    for (const role of roles) {
+      await Role.upsert(role, { transaction });
+    }
+
+    await transaction.commit();
+    return { inserted: roles.length };
+  } catch (error) {
+    await transaction.rollback();
+    throw error;
+  }
+};
+
+if (require.main === module) {
+  seedRoles()
+    .then(result => {
+      console.log(`Seeded ${result.inserted} roles.`);
+      process.exit(0);
+    })
+    .catch(error => {
+      console.error('Failed to seed roles:', error);
+      process.exit(1);
+    });
+}
+
+module.exports = { seedRoles, roles };

--- a/backend/scripts/seedUsers.js
+++ b/backend/scripts/seedUsers.js
@@ -1,0 +1,93 @@
+const bcrypt = require('bcryptjs');
+
+const { initDb, sequelize } = require('../db');
+const { User, Role } = require('../models');
+
+const users = [
+  {
+    name: 'Admin User',
+    email: 'admin@example.com',
+    password: 'password',
+    roleName: 'admin',
+  },
+  {
+    name: 'Regional Manager',
+    email: 'manager@example.com',
+    password: 'password',
+    roleName: 'manager',
+  },
+  {
+    name: 'Meredith Grey',
+    email: 'meredith.grey@example.com',
+    password: 'password',
+    roleName: 'rep',
+  },
+  {
+    name: 'Derek Shepherd',
+    email: 'derek.shepherd@example.com',
+    password: 'password',
+    roleName: 'rep',
+  },
+  {
+    name: 'Miranda Bailey',
+    email: 'miranda.bailey@example.com',
+    password: 'password',
+    roleName: 'rep',
+  },
+];
+
+const seedUsers = async () => {
+  await initDb();
+  const transaction = await sequelize.transaction();
+
+  try {
+    const roleCache = new Map();
+
+    const getRole = async roleName => {
+      if (!roleCache.has(roleName)) {
+        const role = await Role.findOne({ where: { name: roleName }, transaction });
+
+        if (!role) {
+          throw new Error(`Role \"${roleName}\" has not been seeded yet.`);
+        }
+
+        roleCache.set(roleName, role);
+      }
+
+      return roleCache.get(roleName);
+    };
+
+    for (const user of users) {
+      const role = await getRole(user.roleName);
+      const passwordHash = await bcrypt.hash(user.password, 10);
+      const payload = {
+        name: user.name,
+        email: user.email.toLowerCase(),
+        passwordHash,
+        roleId: role.id,
+      };
+
+      await User.upsert(payload, { transaction });
+    }
+
+    await transaction.commit();
+    return { inserted: users.length };
+  } catch (error) {
+    await transaction.rollback();
+    throw error;
+  }
+};
+
+if (require.main === module) {
+  seedUsers()
+    .then(result => {
+      console.log(`Seeded ${result.inserted} users.`);
+      process.exit(0);
+    })
+    .catch(error => {
+      console.error('Failed to seed users:', error);
+      process.exit(1);
+    });
+}
+
+module.exports = { seedUsers, users };

--- a/backend/scripts/seedVisits.js
+++ b/backend/scripts/seedVisits.js
@@ -1,0 +1,132 @@
+const { initDb, sequelize } = require('../db');
+const { Territory, SalesRep, Hcp, Visit } = require('../models');
+const sampleData = require('../db/sampleData');
+
+const seedVisits = async () => {
+  await initDb();
+  const transaction = await sequelize.transaction();
+
+  try {
+    const territoryByCode = new Map();
+    for (const territory of sampleData.territories) {
+      const [record, created] = await Territory.findOrCreate({
+        where: { code: territory.code },
+        defaults: territory,
+        transaction,
+      });
+
+      if (!created) {
+        await record.update({ name: territory.name }, { transaction });
+      }
+
+      territoryByCode.set(record.code, record);
+    }
+
+    const hcpByKey = new Map();
+    for (const hcp of sampleData.hcps) {
+      const [record, created] = await Hcp.findOrCreate({
+        where: { name: hcp.name, areaTag: hcp.areaTag },
+        defaults: hcp,
+        transaction,
+      });
+
+      if (!created) {
+        await record.update(
+          {
+            specialty: hcp.specialty,
+            phone: hcp.phone || null,
+            email: hcp.email || null,
+          },
+          { transaction }
+        );
+      }
+
+      hcpByKey.set(`${record.name}|${record.areaTag}`, record);
+    }
+
+    const salesRepByName = new Map();
+    for (const rep of sampleData.salesReps) {
+      const territory = territoryByCode.get(rep.territoryCode) || null;
+      const [record, created] = await SalesRep.findOrCreate({
+        where: { name: rep.name },
+        defaults: {
+          name: rep.name,
+          email: rep.email || null,
+          territoryId: territory ? territory.id : null,
+        },
+        transaction,
+      });
+
+      if (!created) {
+        await record.update(
+          {
+            email: rep.email || null,
+            territoryId: territory ? territory.id : null,
+          },
+          { transaction }
+        );
+      }
+
+      salesRepByName.set(record.name, record);
+    }
+
+    let inserted = 0;
+    for (const visit of sampleData.visits) {
+      const territory = territoryByCode.get(visit.territoryCode);
+      const rep = salesRepByName.get(visit.repName);
+      const hcp = hcpByKey.get(`${visit.hcpName}|${visit.hcpAreaTag}`);
+
+      if (!territory || !rep || !hcp) {
+        throw new Error(`Invalid visit reference for ${visit.repName} / ${visit.hcpName}.`);
+      }
+
+      const payload = {
+        visitDate: visit.visitDate,
+        status: visit.status,
+        durationMinutes: visit.durationMinutes,
+        notes: visit.notes || null,
+        repId: rep.id,
+        hcpId: hcp.id,
+        territoryId: territory.id,
+      };
+
+      const [record, created] = await Visit.findOrCreate({
+        where: {
+          visitDate: visit.visitDate,
+          repId: rep.id,
+          hcpId: hcp.id,
+        },
+        defaults: payload,
+        transaction,
+      });
+
+      if (!created) {
+        await record.update(payload, { transaction });
+      }
+
+      if (created) {
+        inserted += 1;
+      }
+    }
+
+    await transaction.commit();
+    return { inserted };
+  } catch (error) {
+    await transaction.rollback();
+    throw error;
+  }
+};
+
+if (require.main === module) {
+  seedVisits()
+    .then(result => {
+      console.log(`Seeded visits. ${result.inserted} new row(s) added.`);
+      process.exit(0);
+    })
+    .catch(error => {
+      console.error('Failed to seed visits:', error);
+      process.exit(1);
+    });
+}
+
+module.exports = { seedVisits };


### PR DESCRIPTION
## Summary
- introduce Role and User models and switch the login endpoint to authenticate against the database
- add dedicated Sequelize seed scripts for roles, users, and visits with npm helpers and documentation updates
- ensure visits seeding is idempotent via unique constraints and Jest coverage

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139608e1bc8327ad0d74d2b4910938)